### PR TITLE
Fixed encoding issues

### DIFF
--- a/swt/SwtRandomAccessFile.java
+++ b/swt/SwtRandomAccessFile.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 
 public class SwtRandomAccessFile extends RandomAccessFile {
+	private final String CHARSET = "Windows-1252";
 
 	public SwtRandomAccessFile(File file, String mode) throws IOException {
 		super(file, mode);
@@ -49,10 +50,10 @@ public class SwtRandomAccessFile extends RandomAccessFile {
 		}
 		for(int byteIndex = 0; byteIndex < numBytesRead; byteIndex++) {
 			if(byteArray[byteIndex] == 0) {
-				return new String(byteArray, 0, byteIndex);
+				return new String(byteArray, 0, byteIndex, CHARSET);
 			}
 		}
-		return new String(byteArray, 0, numBytesRead);
+		return new String(byteArray, 0, numBytesRead, CHARSET);
 	}
 	
 	public void writeNullTerminatedString(String str) throws IOException {

--- a/tournament/Player.java
+++ b/tournament/Player.java
@@ -133,12 +133,12 @@ public class Player {
 		}
 		
 		if(pointsDoubled == 1) {
-			return "½";
+			return "\u00BD";
 		}
 		else {
 			String points = String.valueOf(pointsDoubled / 2);
 			if(pointsDoubled % 2 != 0) {
-				points += "½";
+				points += "\u00BD";
 			}
 			return points;
 		}

--- a/tournament/SingleResult.java
+++ b/tournament/SingleResult.java
@@ -23,7 +23,7 @@ public enum SingleResult {
 	
 	NONE (0, "?", "?"),
 	LOSS (0, "0", "-"),
-	DRAW (1, "½", "="),
+	DRAW (1, "\u00BD", "="),
 	WIN  (2, "1", "+");
 	
 	private final int pointsDoubled;


### PR DESCRIPTION
There are two issues with string encodings.
1. When parsing strings in SWT file with unknown character set java will assume it's UTF-8 but it's not.
2. Non-ASCII-Characters in source files may be displayed wrong. Better escape them.
